### PR TITLE
fix: the parameters for the call to run_test in run_single_test are reversed

### DIFF
--- a/source/run_test.cpp
+++ b/source/run_test.cpp
@@ -234,7 +234,7 @@ void run_single_test(int test_number) {
 
     // Run the specified test and output results
     test_point &test = contest[test_number];
-    run_test(test.n, test.k, test.esno, test.n_block, test.opt_avg, run_stats);
+    run_test(test.k, test.n, test.esno, test.n_block, test.opt_avg, run_stats);
     int n_sample = run_stats.n_sample();
     auto sum = run_stats.sum();
     std::array<float, 4> mean;


### PR DESCRIPTION
In the run_test.cpp file at line 237, looks like the parameters for the call to **run_test** function are reversed. Instead of (test.n, test.k, ...) it should be (test.k, test.n, ...). 

Refer to line 125 in the same file for details.